### PR TITLE
Fixed #9 - Non-Functional ThemeUI Styles

### DIFF
--- a/src/theme/scales/radii.js
+++ b/src/theme/scales/radii.js
@@ -1,0 +1,6 @@
+export const radii = ['4px', '16px']
+
+Object.assign(radii, {
+  card: '4px',
+  icon: '16px'
+})


### PR DESCRIPTION
It seems the root cause of this was the empty `radii.js` file, a scale imported by the main theme object. In prod, the empty file cause the theme to fail to load entirely, while in dev the empty file was simply ignored.