### PR TITLE
Fixed #11 - Config menu toggle button is not visible on mobile

### DIFF
--- a/src/theme/variants/layout.js
+++ b/src/theme/variants/layout.js
@@ -6,8 +6,8 @@ export const mobile = {
   gridTemplateColumns: 'min-content 1fr min-content',
   gridTemplateAreas: '"leftMenu title rightMenu" "content content content"',
   overflow: 'clip',
-  width: '100vw',
-  height: '100vh',
+  width: '100%',
+  height: '100%',
 
   headerBar: {
     gridColumnStart: 1,

--- a/src/theme/variants/layout.js
+++ b/src/theme/variants/layout.js
@@ -1,4 +1,5 @@
 export const mobile = {
+  position: 'fixed',
   display: 'grid',
   gridGap: 0,
   gridTemplateRows: 'min-content 1fr',


### PR DESCRIPTION
`vw` and `vh` units behave differently on most mobile browsers than desktop browsers - values of `100vw` and `100vh` will cause content to paint below the viewport due to mobile browser URL bars visible on page load. A solution that seems to work across platforms is to set the position of the root layout element to `fixed` and the dimensions to `100%`. This pull request implements this fix.

For more information:
https://developer.chrome.com/blog/url-bar-resizing/